### PR TITLE
Creación de las migraciones para PostgreSQL cambiando las configuraciones

### DIFF
--- a/Votica.EntityFrameworkCore/Configurations/OptionConfiguration.cs
+++ b/Votica.EntityFrameworkCore/Configurations/OptionConfiguration.cs
@@ -9,8 +9,11 @@ namespace Votica.EntityFrameworkCore.Configurations
         public void Configure(EntityTypeBuilder<Option> builder)
         {
             builder.ToTable("options")
-                .HasKey(o => o.Id)
-                .HasName("id");
+                .HasKey(o => o.Id);
+
+            builder.Property(o => o.Id)
+                .HasColumnName("id")
+                .ValueGeneratedOnAdd();
             
             builder.Property(o => o.Name)
                 .HasColumnName("name")

--- a/Votica.EntityFrameworkCore/Configurations/ParticipantConfiguration.cs
+++ b/Votica.EntityFrameworkCore/Configurations/ParticipantConfiguration.cs
@@ -9,8 +9,7 @@ namespace Votica.EntityFrameworkCore.Configurations
         public void Configure(EntityTypeBuilder<Participant> builder)
         {
             builder.ToTable("participants")
-                .HasKey(p => p.Email)
-                .HasName("email");
+                .HasKey(p => p.Email);
 
             builder.Property(p => p.Email)
                 .HasColumnName("email")

--- a/Votica.EntityFrameworkCore/Configurations/PollConfiguration.cs
+++ b/Votica.EntityFrameworkCore/Configurations/PollConfiguration.cs
@@ -9,8 +9,11 @@ namespace Votica.EntityFrameworkCore.Configurations
         public void Configure(EntityTypeBuilder<Poll> builder)
         {
             builder.ToTable("polls")
-                .HasKey(p => p.Id)
-                .HasName("id");
+                .HasKey(p => p.Id);
+
+            builder.Property(p => p.Id)
+                .HasColumnName("id")
+                .ValueGeneratedOnAdd();
             
             builder.Property(p => p.Name)
                 .HasColumnName("name")
@@ -25,12 +28,12 @@ namespace Votica.EntityFrameworkCore.Configurations
             
             builder.Property(p => p.CreationDate)
                 .HasColumnName("creationDate")
-                .HasColumnType("datetime")
+                .HasColumnType("timestamptz")
                 .IsRequired();
             
             builder.Property(p => p.ExpirationDate)
                 .HasColumnName("expirationDate")
-                .HasColumnType("datetime")
+                .HasColumnType("timestamptz")
                 .IsRequired();
 
             builder.HasMany(poll => poll.Questions)

--- a/Votica.EntityFrameworkCore/Configurations/QuestionConfiguration.cs
+++ b/Votica.EntityFrameworkCore/Configurations/QuestionConfiguration.cs
@@ -9,8 +9,11 @@ namespace Votica.EntityFrameworkCore.Configurations
         public void Configure(EntityTypeBuilder<Question> builder)
         {
             builder.ToTable("questions")
-                .HasKey(q => q.Id)
-                .HasName("id");
+                .HasKey(q => q.Id);
+
+            builder.Property(q => q.Id)
+                .HasColumnName("id")
+                .ValueGeneratedOnAdd();
             
             builder.Property(q => q.Name)
                 .HasColumnName("name")

--- a/Votica.EntityFrameworkCore/Configurations/QuestionTypeConfiguration.cs
+++ b/Votica.EntityFrameworkCore/Configurations/QuestionTypeConfiguration.cs
@@ -9,8 +9,11 @@ namespace Votica.EntityFrameworkCore.Configurations
         public void Configure(EntityTypeBuilder<QuestionType> builder)
         {
             builder.ToTable("questionTypes")
-                .HasKey(qt => qt.Id)
-                .HasName("id");
+                .HasKey(qt => qt.Id);
+
+            builder.Property(qt => qt.Id)
+                .HasColumnName("id")
+                .ValueGeneratedOnAdd();
             
             builder.Property(qt => qt.Name)
                 .HasColumnName("name")

--- a/Votica.EntityFrameworkCore/Migrations/20190619194824_InitialCreate.Designer.cs
+++ b/Votica.EntityFrameworkCore/Migrations/20190619194824_InitialCreate.Designer.cs
@@ -4,24 +4,28 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Votica.EntityFrameworkCore;
 
 namespace Votica.EntityFrameworkCore.Migrations
 {
     [DbContext(typeof(VoticaDbContext))]
-    [Migration("20190618201901_InitialCreate")]
+    [Migration("20190619194824_InitialCreate")]
     partial class InitialCreate
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "2.2.4-servicing-10062");
+                .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn)
+                .HasAnnotation("ProductVersion", "2.2.4-servicing-10062")
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             modelBuilder.Entity("Votica.Domain.Option", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasColumnName("id");
 
                     b.Property<string>("Name")
                         .IsRequired()
@@ -31,8 +35,7 @@ namespace Votica.EntityFrameworkCore.Migrations
 
                     b.Property<int?>("QuestionId");
 
-                    b.HasKey("Id")
-                        .HasName("id");
+                    b.HasKey("Id");
 
                     b.HasIndex("QuestionId");
 
@@ -46,8 +49,7 @@ namespace Votica.EntityFrameworkCore.Migrations
                         .HasColumnName("email")
                         .HasColumnType("varchar(60)");
 
-                    b.HasKey("Email")
-                        .HasName("email");
+                    b.HasKey("Email");
 
                     b.ToTable("participants");
                 });
@@ -68,11 +70,12 @@ namespace Votica.EntityFrameworkCore.Migrations
             modelBuilder.Entity("Votica.Domain.Poll", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasColumnName("id");
 
                     b.Property<DateTimeOffset>("CreationDate")
                         .HasColumnName("creationDate")
-                        .HasColumnType("datetime");
+                        .HasColumnType("timestamptz");
 
                     b.Property<string>("Description")
                         .HasColumnName("description")
@@ -81,7 +84,7 @@ namespace Votica.EntityFrameworkCore.Migrations
 
                     b.Property<DateTimeOffset>("ExpirationDate")
                         .HasColumnName("expirationDate")
-                        .HasColumnType("datetime");
+                        .HasColumnType("timestamptz");
 
                     b.Property<string>("Name")
                         .IsRequired()
@@ -89,8 +92,7 @@ namespace Votica.EntityFrameworkCore.Migrations
                         .HasColumnType("varchar(150)")
                         .HasMaxLength(150);
 
-                    b.HasKey("Id")
-                        .HasName("id");
+                    b.HasKey("Id");
 
                     b.ToTable("polls");
                 });
@@ -98,7 +100,8 @@ namespace Votica.EntityFrameworkCore.Migrations
             modelBuilder.Entity("Votica.Domain.Question", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasColumnName("id");
 
                     b.Property<string>("Name")
                         .IsRequired()
@@ -110,8 +113,7 @@ namespace Votica.EntityFrameworkCore.Migrations
 
                     b.Property<int>("TypeId");
 
-                    b.HasKey("Id")
-                        .HasName("id");
+                    b.HasKey("Id");
 
                     b.HasIndex("PollId");
 
@@ -123,7 +125,8 @@ namespace Votica.EntityFrameworkCore.Migrations
             modelBuilder.Entity("Votica.Domain.QuestionType", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasColumnName("id");
 
                     b.Property<string>("Name")
                         .IsRequired()
@@ -131,8 +134,7 @@ namespace Votica.EntityFrameworkCore.Migrations
                         .HasColumnType("varchar(35)")
                         .HasMaxLength(35);
 
-                    b.HasKey("Id")
-                        .HasName("id");
+                    b.HasKey("Id");
 
                     b.ToTable("questionTypes");
                 });

--- a/Votica.EntityFrameworkCore/Migrations/20190619194824_InitialCreate.cs
+++ b/Votica.EntityFrameworkCore/Migrations/20190619194824_InitialCreate.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace Votica.EntityFrameworkCore.Migrations
 {
@@ -15,62 +16,62 @@ namespace Votica.EntityFrameworkCore.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("email", x => x.email);
+                    table.PrimaryKey("PK_participants", x => x.email);
                 });
 
             migrationBuilder.CreateTable(
                 name: "polls",
                 columns: table => new
                 {
-                    Id = table.Column<int>(nullable: false)
-                        .Annotation("Sqlite:Autoincrement", true),
+                    id = table.Column<int>(nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn),
                     name = table.Column<string>(type: "varchar(150)", maxLength: 150, nullable: false),
                     description = table.Column<string>(type: "varchar(255)", maxLength: 255, nullable: true),
-                    creationDate = table.Column<DateTimeOffset>(type: "datetime", nullable: false),
-                    expirationDate = table.Column<DateTimeOffset>(type: "datetime", nullable: false)
+                    creationDate = table.Column<DateTimeOffset>(type: "timestamptz", nullable: false),
+                    expirationDate = table.Column<DateTimeOffset>(type: "timestamptz", nullable: false)
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("id", x => x.Id);
+                    table.PrimaryKey("PK_polls", x => x.id);
                 });
 
             migrationBuilder.CreateTable(
                 name: "questionTypes",
                 columns: table => new
                 {
-                    Id = table.Column<int>(nullable: false)
-                        .Annotation("Sqlite:Autoincrement", true),
+                    id = table.Column<int>(nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn),
                     name = table.Column<string>(type: "varchar(35)", maxLength: 35, nullable: false)
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("id", x => x.Id);
+                    table.PrimaryKey("PK_questionTypes", x => x.id);
                 });
 
             migrationBuilder.CreateTable(
                 name: "questions",
                 columns: table => new
                 {
-                    Id = table.Column<int>(nullable: false)
-                        .Annotation("Sqlite:Autoincrement", true),
+                    id = table.Column<int>(nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn),
                     name = table.Column<string>(type: "varchar(150)", maxLength: 150, nullable: false),
                     TypeId = table.Column<int>(nullable: false),
                     PollId = table.Column<int>(nullable: false)
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("id", x => x.Id);
+                    table.PrimaryKey("PK_questions", x => x.id);
                     table.ForeignKey(
                         name: "FK_questions_polls_PollId",
                         column: x => x.PollId,
                         principalTable: "polls",
-                        principalColumn: "Id",
+                        principalColumn: "id",
                         onDelete: ReferentialAction.Cascade);
                     table.ForeignKey(
                         name: "FK_questions_questionTypes_TypeId",
                         column: x => x.TypeId,
                         principalTable: "questionTypes",
-                        principalColumn: "Id",
+                        principalColumn: "id",
                         onDelete: ReferentialAction.Cascade);
                 });
 
@@ -78,19 +79,19 @@ namespace Votica.EntityFrameworkCore.Migrations
                 name: "options",
                 columns: table => new
                 {
-                    Id = table.Column<int>(nullable: false)
-                        .Annotation("Sqlite:Autoincrement", true),
+                    id = table.Column<int>(nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn),
                     name = table.Column<string>(type: "varchar(60)", maxLength: 60, nullable: false),
                     QuestionId = table.Column<int>(nullable: true)
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("id", x => x.Id);
+                    table.PrimaryKey("PK_options", x => x.id);
                     table.ForeignKey(
                         name: "FK_options_questions_QuestionId",
                         column: x => x.QuestionId,
                         principalTable: "questions",
-                        principalColumn: "Id",
+                        principalColumn: "id",
                         onDelete: ReferentialAction.Restrict);
                 });
 
@@ -108,7 +109,7 @@ namespace Votica.EntityFrameworkCore.Migrations
                         name: "FK_optionsPerParticipant_options_OptionId",
                         column: x => x.OptionId,
                         principalTable: "options",
-                        principalColumn: "Id",
+                        principalColumn: "id",
                         onDelete: ReferentialAction.Cascade);
                     table.ForeignKey(
                         name: "FK_optionsPerParticipant_participants_ParticipantEmail",

--- a/Votica.EntityFrameworkCore/Migrations/VoticaDbContextModelSnapshot.cs
+++ b/Votica.EntityFrameworkCore/Migrations/VoticaDbContextModelSnapshot.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Votica.EntityFrameworkCore;
 
 namespace Votica.EntityFrameworkCore.Migrations
@@ -14,12 +15,15 @@ namespace Votica.EntityFrameworkCore.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "2.2.4-servicing-10062");
+                .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn)
+                .HasAnnotation("ProductVersion", "2.2.4-servicing-10062")
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             modelBuilder.Entity("Votica.Domain.Option", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasColumnName("id");
 
                     b.Property<string>("Name")
                         .IsRequired()
@@ -29,8 +33,7 @@ namespace Votica.EntityFrameworkCore.Migrations
 
                     b.Property<int?>("QuestionId");
 
-                    b.HasKey("Id")
-                        .HasName("id");
+                    b.HasKey("Id");
 
                     b.HasIndex("QuestionId");
 
@@ -44,8 +47,7 @@ namespace Votica.EntityFrameworkCore.Migrations
                         .HasColumnName("email")
                         .HasColumnType("varchar(60)");
 
-                    b.HasKey("Email")
-                        .HasName("email");
+                    b.HasKey("Email");
 
                     b.ToTable("participants");
                 });
@@ -66,11 +68,12 @@ namespace Votica.EntityFrameworkCore.Migrations
             modelBuilder.Entity("Votica.Domain.Poll", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasColumnName("id");
 
                     b.Property<DateTimeOffset>("CreationDate")
                         .HasColumnName("creationDate")
-                        .HasColumnType("datetime");
+                        .HasColumnType("timestamptz");
 
                     b.Property<string>("Description")
                         .HasColumnName("description")
@@ -79,7 +82,7 @@ namespace Votica.EntityFrameworkCore.Migrations
 
                     b.Property<DateTimeOffset>("ExpirationDate")
                         .HasColumnName("expirationDate")
-                        .HasColumnType("datetime");
+                        .HasColumnType("timestamptz");
 
                     b.Property<string>("Name")
                         .IsRequired()
@@ -87,8 +90,7 @@ namespace Votica.EntityFrameworkCore.Migrations
                         .HasColumnType("varchar(150)")
                         .HasMaxLength(150);
 
-                    b.HasKey("Id")
-                        .HasName("id");
+                    b.HasKey("Id");
 
                     b.ToTable("polls");
                 });
@@ -96,7 +98,8 @@ namespace Votica.EntityFrameworkCore.Migrations
             modelBuilder.Entity("Votica.Domain.Question", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasColumnName("id");
 
                     b.Property<string>("Name")
                         .IsRequired()
@@ -108,8 +111,7 @@ namespace Votica.EntityFrameworkCore.Migrations
 
                     b.Property<int>("TypeId");
 
-                    b.HasKey("Id")
-                        .HasName("id");
+                    b.HasKey("Id");
 
                     b.HasIndex("PollId");
 
@@ -121,7 +123,8 @@ namespace Votica.EntityFrameworkCore.Migrations
             modelBuilder.Entity("Votica.Domain.QuestionType", b =>
                 {
                     b.Property<int>("Id")
-                        .ValueGeneratedOnAdd();
+                        .ValueGeneratedOnAdd()
+                        .HasColumnName("id");
 
                     b.Property<string>("Name")
                         .IsRequired()
@@ -129,8 +132,7 @@ namespace Votica.EntityFrameworkCore.Migrations
                         .HasColumnType("varchar(35)")
                         .HasMaxLength(35);
 
-                    b.HasKey("Id")
-                        .HasName("id");
+                    b.HasKey("Id");
 
                     b.ToTable("questionTypes");
                 });

--- a/Votica.EntityFrameworkCore/VoticaContextFactory.cs
+++ b/Votica.EntityFrameworkCore/VoticaContextFactory.cs
@@ -13,7 +13,7 @@ namespace Votica.EntityFrameworkCore
         public VoticaDbContext CreateDbContext(string[] args)
         {
             var optionsBuilder = new DbContextOptionsBuilder<VoticaDbContext>();
-            optionsBuilder.UseSqlite("Data Source=votica.db");
+            optionsBuilder.UseNpgsql("Host=localhost;Database=votica_db;Username=votica;Password=votica123");
 
             return new VoticaDbContext(optionsBuilder.Options);
         }

--- a/Votica.EntityFrameworkCore/VoticaDbContext.cs
+++ b/Votica.EntityFrameworkCore/VoticaDbContext.cs
@@ -14,11 +14,8 @@ namespace Votica.EntityFrameworkCore
     /// </summary>
     public class VoticaDbContext : DbContext, IDatabaseContext
     {
-        public VoticaDbContext(DbContextOptions<VoticaDbContext> options)
-            : base(options)
-        {
-            
-        }
+        public VoticaDbContext(DbContextOptions<VoticaDbContext> options) : base(options)
+        {}
 
         public void Commit()
         {
@@ -76,6 +73,10 @@ namespace Votica.EntityFrameworkCore
             }
             return entityExist;
         }
+
+        // protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        //     => optionsBuilder.UseNpgsql("Host=localhost;Database=votica_db;Username=rubenarrebola;Password=ruben123");
+
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {


### PR DESCRIPTION
- Se modifican las configuraciones que daban error al crear la base de datos en postgres a principio funcionaba porque no daba problemas con sqlite.
- Además de que los datetimes se han tenido que cambiar a timestamps con zona horaria (únicamente en las configuraciones no en el Domain) ya que no hay datetime en postgres
- Se configura la cadena de conexión localhost, user -> votica ; password -> votica123
- Se crean las migraciones correctamente para postgres

```bash
On branch feature/database-configuration
Changes to be committed:
	modified:   Votica.EntityFrameworkCore/Configurations/OptionConfiguration.cs
	modified:   Votica.EntityFrameworkCore/Configurations/ParticipantConfiguration.cs
	modified:   Votica.EntityFrameworkCore/Configurations/PollConfiguration.cs
	modified:   Votica.EntityFrameworkCore/Configurations/QuestionConfiguration.cs
	modified:   Votica.EntityFrameworkCore/Configurations/QuestionTypeConfiguration.cs
	renamed:    Votica.EntityFrameworkCore/Migrations/20190618201901_InitialCreate.Designer.cs -> Votica.EntityFrameworkCore/Migrations/20190619194824_InitialCreate.Designer.cs
	renamed:    Votica.EntityFrameworkCore/Migrations/20190618201901_InitialCreate.cs -> Votica.EntityFrameworkCore/Migrations/20190619194824_InitialCreate.cs
	modified:   Votica.EntityFrameworkCore/Migrations/VoticaDbContextModelSnapshot.cs
	modified:   Votica.EntityFrameworkCore/VoticaContextFactory.cs
	modified:   Votica.EntityFrameworkCore/VoticaDbContext.cs
```